### PR TITLE
git protocol has been disabled by GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "electron-updater": "^4.3.1",
     "eosio-signing-request": "2.3.0",
     "eosjs": "16.0.8",
-    "eosjs2": "git://github.com/aaroncox/eosjs2",
+    "eosjs2": "https://github.com/aaroncox/eosjs2",
     "fast-sha256": "^1.1.1",
     "history": "^4.7.2",
     "humanize-duration": "^3.20.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6290,9 +6290,9 @@ eosjs-ecc@4.0.4:
     ecurve "^1.0.5"
     randombytes "^2.0.5"
 
-"eosjs2@git://github.com/aaroncox/eosjs2":
+"eosjs2@https://github.com/aaroncox/eosjs2":
   version "1.0.0"
-  resolved "git://github.com/aaroncox/eosjs2#0646c5935011445773f5cac6ed0d2b798f5a533a"
+  resolved "https://github.com/aaroncox/eosjs2#0646c5935011445773f5cac6ed0d2b798f5a533a"
   dependencies:
     eosjs v20.0.0
 


### PR DESCRIPTION
## Error
Manual build failed with this error:
_The unauthenticated git protocol on port 9418 is no longer supported_

## Cause
the "git" protocol prefix has been disabled by Github

## Fix
replace with https://

## Additional Info

--> https://stackoverflow.com/questions/70663523/the-unauthenticated-git-protocol-on-port-9418-is-no-longer-supported

Full error below
```
❯ yarn --frozen-lockfile
yarn install v1.22.17
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
error Command failed.
Exit code: 128
Command: git
Arguments: ls-remote --tags --heads git://github.com/aaroncox/eosjs2
Directory: /Users/elohim/play/ual-experiment/anchor
Output:
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```